### PR TITLE
Moved logging of reponame closer to git output for better correlation

### DIFF
--- a/bin/bit
+++ b/bin/bit
@@ -10,8 +10,6 @@ var fs = require('fs'),
   util = require('util'),
   action, params;
 
-function puts(error, stdout, stderr) { util.puts(stdout); }
-
 Bit = {
   initializeNew: function () {
     var path = process.env.PWD;
@@ -93,11 +91,14 @@ Bit = {
 
   _perform: function (repoName,path,args) {
     var toPerform = args.join(' '), exec = require('child_process').exec;
-    if (repoName) console.log("# "+ (repoName ? repoName : 'root') +" git "+args);
-    
     if (path && !path.match(/\/$/)) path+='/';
     
-    if (path) { exec('git --git-dir='+path+'.git --work-tree='+path+' '+toPerform, puts); }
+    if (path) {
+      exec('git --git-dir='+path+'.git --work-tree='+path+' '+toPerform, function(error, stdout, stderr){
+        console.log("# "+ (repoName ? repoName : 'root') +" git "+args);
+        util.puts(stdout);
+      });
+    }
   },
 
   removeRepository: function (names) {


### PR DESCRIPTION
When i added a few repos and ran `bit status` it gave the following output.

```
# root git st
# repo_1 git status
# repo_2 git status
# repo_3 git status

On branch master
Your branch is up-to-date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.bit/

nothing added to commit but untracked files present (use "git add" to track)

On branch master
Your branch is up-to-date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.bit/

nothing added to commit but untracked files present (use "git add" to track)

On branch master
Your branch is up-to-date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.bit/

nothing added to commit but untracked files present (use "git add" to track)
```

Thought it'd be better if the reponame and the output are displayed together.